### PR TITLE
Add meshes support

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -43,6 +43,7 @@ Each media type handles annotations separately:
 - `clone_volumes_with_annotations()`
 - `clone_pointclouds_with_annotations()`
 - `clone_pointcloud_episodes_with_annotations()`
+- `clone_meshes_with_annotations()` — server-side copy via `api.mesh.upload_ids()`; annotations follow the image model (IDs inline, no `KeyIdMap`)
 
 ### Dataset Tree Helpers
 
@@ -102,7 +103,7 @@ modal.state.items = [{"id":123,"type":"image"}]  # optional: scope to specific i
 TASK_ID = 57919
 ```
 
-`items` type values: `image`, `video`, `volume`, `pointcloud`, `pointcloud_episode`, `dataset`, `job`, `queue`
+`items` type values: `image`, `video`, `volume`, `pointcloud`, `pointcloud_episode`, `mesh`, `dataset`, `job`, `queue`
 
 ## Docker
 

--- a/config.json
+++ b/config.json
@@ -5,7 +5,7 @@
   "type": "app",
   "headless": true,
   "main_script": "src/main.py",
-  "docker_image": "supervisely/data-commander:1.2.28-test",
+  "docker_image": "supervisely/data-commander:1.2.28-test-build-01",
   "instance_version": "6.15.60",
   "system": true,
   "icon": "https://github.com/user-attachments/assets/673c34ac-2f58-4d1c-8679-439e85a25a45",

--- a/config.json
+++ b/config.json
@@ -5,7 +5,7 @@
   "type": "app",
   "headless": true,
   "main_script": "src/main.py",
-  "docker_image": "supervisely/data-commander:1.2.28-test-build-01",
+  "docker_image": "supervisely/data-commander:1.2.28-test-build-02",
   "instance_version": "6.15.60",
   "system": true,
   "icon": "https://github.com/user-attachments/assets/673c34ac-2f58-4d1c-8679-439e85a25a45",

--- a/config.json
+++ b/config.json
@@ -5,8 +5,8 @@
   "type": "app",
   "headless": true,
   "main_script": "src/main.py",
-  "docker_image": "supervisely/data-commander:1.2.28-test-build-02",
-  "instance_version": "6.15.60",
+  "docker_image": "supervisely/base-py-sdk-hardened:6.74.0",
+  "instance_version": "6.17.0",
   "system": true,
   "icon": "https://github.com/user-attachments/assets/673c34ac-2f58-4d1c-8679-439e85a25a45",
   "poster": "https://github.com/user-attachments/assets/09252852-3f49-4bad-b665-14e52458e4c0"

--- a/config.json
+++ b/config.json
@@ -5,7 +5,7 @@
   "type": "app",
   "headless": true,
   "main_script": "src/main.py",
-  "docker_image": "supervisely/base-py-sdk-hardened:6.73.564",
+  "docker_image": "supervisely/data-commander:1.2.28-test",
   "instance_version": "6.15.60",
   "system": true,
   "icon": "https://github.com/user-attachments/assets/673c34ac-2f58-4d1c-8679-439e85a25a45",

--- a/dev_requirements.txt
+++ b/dev_requirements.txt
@@ -2,4 +2,4 @@
 # Pinned to a commit on branch refactor/mesh-image-annotation-model (pip caches
 # branch refs and may not refetch — pin the exact commit). Swap for a pinned
 # `supervisely==<version>` once the mesh changes are released.
-supervisely @ git+https://github.com/supervisely/supervisely.git@ca91828ac6275fae2351a361a041f0dd66b485f1
+supervisely @ git+https://github.com/supervisely/supervisely.git@bfbde02112d94051a6e26a2385ba78924fb5b6f6

--- a/dev_requirements.txt
+++ b/dev_requirements.txt
@@ -1,4 +1,5 @@
 # TEMPORARY: meshes support requires the unreleased mesh SDK.
-# Swap this for a pinned `supervisely==<version>` once the mesh changes are
-# released (SDK branch: refactor/mesh-image-annotation-model).
-supervisely @ git+https://github.com/supervisely/supervisely.git@refactor/mesh-image-annotation-model
+# Pinned to a commit on branch refactor/mesh-image-annotation-model (pip caches
+# branch refs and may not refetch — pin the exact commit). Swap for a pinned
+# `supervisely==<version>` once the mesh changes are released.
+supervisely @ git+https://github.com/supervisely/supervisely.git@ca91828ac6275fae2351a361a041f0dd66b485f1

--- a/dev_requirements.txt
+++ b/dev_requirements.txt
@@ -1,1 +1,4 @@
-supervisely==6.73.564
+# TEMPORARY: meshes support requires the unreleased mesh SDK.
+# Swap this for a pinned `supervisely==<version>` once the mesh changes are
+# released (SDK branch: refactor/mesh-image-annotation-model).
+supervisely @ git+https://github.com/supervisely/supervisely.git@refactor/mesh-image-annotation-model

--- a/dev_requirements.txt
+++ b/dev_requirements.txt
@@ -1,5 +1,7 @@
-# TEMPORARY: meshes support requires the unreleased mesh SDK.
-# Pinned to a commit on branch refactor/mesh-image-annotation-model (pip caches
+# TEMPORARY: feature support requires the unreleased SDK.
+# Pinned to a commit on branch refactor/<branch_name> (pip caches
 # branch refs and may not refetch — pin the exact commit). Swap for a pinned
-# `supervisely==<version>` once the mesh changes are released.
-supervisely @ git+https://github.com/supervisely/supervisely.git@bfbde02112d94051a6e26a2385ba78924fb5b6f6
+# `supervisely==<version>` once the changes are released.
+# supervisely @ git+https://github.com/supervisely/supervisely.git@ca91828ac6275fae2351a361a041f0dd66b485f1
+
+supervisely==6.74.0

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -4,5 +4,6 @@ FROM supervisely/base-py-sdk:6.73.580
 # Pinned to a commit on branch refactor/mesh-image-annotation-model — pip caches
 # branch refs and may not refetch, so pin the exact commit. Remove this and bump
 # the base image once the mesh changes are released.
-RUN pip install --no-cache-dir --force-reinstall --no-deps \
-    "supervisely @ git+https://github.com/supervisely/supervisely.git@ca91828ac6275fae2351a361a041f0dd66b485f1"
+RUN RELEASE_VERSION="0.0.0+bfbde02" \
+    python3 -m pip install --no-cache-dir --force-reinstall --no-deps \
+    "https://github.com/supervisely/supervisely/archive/bfbde02112d94051a6e26a2385ba78924fb5b6f6.tar.gz"

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,7 +1,8 @@
-FROM supervisely/base-py-sdk:6.73.537
+FROM supervisely/base-py-sdk:6.73.580
 
 # TEMPORARY: meshes support requires the unreleased mesh SDK.
-# Remove this and bump the base image once the mesh changes are released
-# (SDK branch: refactor/mesh-image-annotation-model).
+# Pinned to a commit on branch refactor/mesh-image-annotation-model — pip caches
+# branch refs and may not refetch, so pin the exact commit. Remove this and bump
+# the base image once the mesh changes are released.
 RUN pip install --no-cache-dir --force-reinstall --no-deps \
-    "supervisely @ git+https://github.com/supervisely/supervisely.git@refactor/mesh-image-annotation-model"
+    "supervisely @ git+https://github.com/supervisely/supervisely.git@ca91828ac6275fae2351a361a041f0dd66b485f1"

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,1 +1,7 @@
 FROM supervisely/base-py-sdk:6.73.537
+
+# TEMPORARY: meshes support requires the unreleased mesh SDK.
+# Remove this and bump the base image once the mesh changes are released
+# (SDK branch: refactor/mesh-image-annotation-model).
+RUN pip install --no-cache-dir --force-reinstall --no-deps \
+    "supervisely @ git+https://github.com/supervisely/supervisely.git@refactor/mesh-image-annotation-model"

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,9 +1,8 @@
-FROM supervisely/base-py-sdk:6.73.580
+FROM supervisely/base-py-sdk:6.74.0
 
-# TEMPORARY: meshes support requires the unreleased mesh SDK.
-# Pinned to a commit on branch refactor/mesh-image-annotation-model — pip caches
+# TEMPORARY: new feature support requires the unreleased SDK.
+# Pinned to a commit on branch refactor/<branch_name> — pip caches
 # branch refs and may not refetch, so pin the exact commit. Remove this and bump
-# the base image once the mesh changes are released.
-RUN RELEASE_VERSION="0.0.0+bfbde02" \
-    python3 -m pip install --no-cache-dir --force-reinstall --no-deps \
-    "https://github.com/supervisely/supervisely/archive/bfbde02112d94051a6e26a2385ba78924fb5b6f6.tar.gz"
+# the base image once the changes are released.
+#RUN pip install --no-cache-dir --force-reinstall --no-deps \
+#    "supervisely @ git+https://github.com/supervisely/supervisely.git@ca91828ac6275fae2351a361a041f0dd66b485f1"

--- a/docker/build-push.sh
+++ b/docker/build-push.sh
@@ -1,2 +1,2 @@
-docker build -t supervisely/data-commander:1.2.28-test-build-01 .
-docker push supervisely/data-commander:1.2.28-test-build-01
+docker build -t supervisely/data-commander:1.2.28-test-build-02 .
+docker push supervisely/data-commander:1.2.28-test-build-02

--- a/docker/build-push.sh
+++ b/docker/build-push.sh
@@ -1,0 +1,2 @@
+docker build -t supervisely/data-commander:1.2.28-test-build-01 .
+docker push supervisely/data-commander:1.2.28-test-build-01

--- a/src/main.py
+++ b/src/main.py
@@ -69,6 +69,7 @@ class JSONKEYS:
     VOLUME = "volume"
     POINTCLOUD = "pointcloud"
     POINTCLOUD_EPISODE = "pointcloud_episode"
+    MESH = "mesh"
     REVIEW_STATUS = "reviewStatus"
     ACCEPTED = "accepted"
     REJECTED = "rejected"
@@ -1124,6 +1125,116 @@ def clone_pointcloud_episodes_with_annotations(
     return [dst_infos_dict[src.id] for src in pointcloud_episode_infos]
 
 
+def clone_meshes_with_annotations(
+    mesh_infos: List[sly.MeshInfo],
+    dst_dataset_id: int,
+    project_meta: sly.ProjectMeta,
+    options,
+    progress_cb=None,
+) -> List[sly.MeshInfo]:
+    if len(mesh_infos) == 0:
+        return []
+
+    existing = run_in_executor(api.mesh.get_list, dst_dataset_id)
+    existing = {info.name: info for info in existing}
+    if options[JSONKEYS.CONFLICT_RESOLUTION_MODE] == JSONKEYS.CONFLICT_SKIP:
+        mesh_infos = [info for info in mesh_infos if info.name not in existing]
+
+    if len(mesh_infos) == 0:
+        return []
+
+    src_dataset_id = mesh_infos[0].dataset_id
+
+    def _copy_meshes(names, ids, metas, infos):
+        # Server-side copy by reference (link/hash); no download or re-upload.
+        uploaded = api.mesh.upload_ids(
+            dst_dataset_id,
+            names=names,
+            ids=ids,
+            metas=metas,
+            infos=infos,
+        )
+        return infos, uploaded
+
+    def _copy_anns(src, dst):
+        src_ids = [info.id for info in src]
+        dst_ids = [info.id for info in dst]
+        ann_jsons = run_in_executor(
+            api.mesh.annotation.download_bulk, src_dataset_id, src_ids
+        )
+        tasks = []
+        # Mesh annotations follow the image model: server IDs are inline in the
+        # JSON, so the transfer dict can be appended directly (no KeyIdMap).
+        for ann_json, dst_id in zip(ann_jsons, dst_ids):
+            tasks.append(
+                executor.submit(api.mesh.annotation.append, dst_id, ann_json)
+            )
+        for task in as_completed(tasks):
+            task.result()
+        return src, dst
+
+    def _maybe_copy_anns_and_replace(src, dst):
+        if options[JSONKEYS.CLONE_ANNOTATIONS]:
+            src, dst = _copy_anns(src, dst)
+        return maybe_replace(src, dst, to_rename, existing)
+
+    to_rename = {}
+    copy_mesh_tasks = []
+    for src_mesh_infos in sly.batched(mesh_infos):
+        names = [info.name for info in src_mesh_infos]
+        ids = [info.id for info in src_mesh_infos]
+        metas = [info.meta for info in src_mesh_infos]
+        now = datetime.now().strftime("%Y_%m_%d_%H_%M_%S")
+        if options[JSONKEYS.CONFLICT_RESOLUTION_MODE] in [
+            JSONKEYS.CONFLICT_RENAME,
+            JSONKEYS.CONFLICT_REPLACE,
+        ]:
+            for i, name in enumerate(names):
+                if name in existing:
+                    names[i] = (
+                        ".".join(name.split(".")[:-1])
+                        + "_"
+                        + now
+                        + "."
+                        + name.split(".")[-1]
+                    )
+                    if (
+                        options[JSONKEYS.CONFLICT_RESOLUTION_MODE]
+                        == JSONKEYS.CONFLICT_REPLACE
+                    ):
+                        to_rename[names[i]] = name
+
+        copy_mesh_tasks.append(
+            executor.submit(
+                _copy_meshes,
+                names=names,
+                ids=ids,
+                metas=metas,
+                infos=src_mesh_infos,
+            )
+        )
+
+    local_executor = ThreadPoolExecutor(max_workers=5)
+    replace_tasks = []
+    src_id_to_dst_info = {}
+    for task in as_completed(copy_mesh_tasks):
+        src_mesh_infos, uploaded_mesh_infos = task.result()
+        for s, d in zip(src_mesh_infos, uploaded_mesh_infos):
+            src_id_to_dst_info[s.id] = d
+        replace_tasks.append(
+            local_executor.submit(
+                _maybe_copy_anns_and_replace, src_mesh_infos, uploaded_mesh_infos
+            )
+        )
+
+    for task in as_completed(replace_tasks):
+        src, _ = task.result()
+        if progress_cb is not None:
+            progress_cb(len(src))
+
+    return [src_id_to_dst_info[info.id] for info in mesh_infos]
+
+
 def clone_items(
     src_dataset_id,
     dst_dataset_id,
@@ -1153,6 +1264,10 @@ def clone_items(
         if src_infos is None:
             src_infos = run_in_executor(api.pointcloud_episode.get_list, src_dataset_id)
         clone_f = clone_pointcloud_episodes_with_annotations
+    elif project_type == str(sly.ProjectType.MESHES):
+        if src_infos is None:
+            src_infos = run_in_executor(api.mesh.get_list, src_dataset_id)
+        clone_f = clone_meshes_with_annotations
     else:
         raise NotImplementedError(
             "Cloning for project type {} is not implemented".format(project_type)
@@ -2080,6 +2195,10 @@ def get_item_infos(
         if dataset_id is None:
             return [api.pointcloud_episode.get_info_by_id(item_id) for item_id in item_ids]
         return api.pointcloud_episode.get_list(dataset_id, filters)
+    if project_type == str(sly.ProjectType.MESHES):
+        if dataset_id is None:
+            return [api.mesh.get_info_by_id(item_id) for item_id in item_ids]
+        return api.mesh.get_list(dataset_id, filters=filters)
     else:
         raise ValueError("Unknown item type")
 

--- a/src/main.py
+++ b/src/main.py
@@ -1146,13 +1146,12 @@ def clone_meshes_with_annotations(
     src_dataset_id = mesh_infos[0].dataset_id
 
     def _copy_meshes(names, ids, metas, infos):
-        # Server-side copy by reference (link/hash); no download or re-upload.
+        # Server-side copy by source id (image-style); no download or re-upload.
         uploaded = api.mesh.upload_ids(
             dst_dataset_id,
             names=names,
             ids=ids,
             metas=metas,
-            infos=infos,
         )
         return infos, uploaded
 


### PR DESCRIPTION
Support the new "meshes" project type in copy/move flows:

- clone_meshes_with_annotations(): server-side copy via api.mesh.upload_ids (copy by reference, no download/re-upload), with skip/rename/replace conflict handling like the other modalities. Annotations follow the image model — server IDs are inline in the JSON, so the transfer dict is appended directly via api.mesh.annotation.append (no KeyIdMap).
- Wire MESHES into clone_items() and get_item_infos(); add JSONKEYS.MESH.

Depends on the unreleased mesh SDK (branch refactor/mesh-image-annotation-model): dev_requirements.txt and docker/Dockerfile temporarily install it from git — swap for a pinned release once merged.