### PR TITLE
Add support for collection items in copy/move actions

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -105,7 +105,7 @@ TASK_ID = 57919
 
 `items` type values: `image`, `video`, `volume`, `pointcloud`, `pointcloud_episode`, `mesh`, `dataset`, `job`, `queue`, `collection`
 
-A `collection` item (entities collection ID) is resolved via `api.entities_collection.get_items()` into a flat list of images processed by a dedicated path (`copy_collection_items_to_dataset()` / `move_collection_items_to_dataset()`) — all images land in the destination dataset without preserving source structure. Works for both `default` and `aiSearch` collection types. Same-named images from different datasets are disambiguated upfront by `disambiguate_collection_names()`: every image involved in a name conflict gets `_<src dataset ID>` appended before the extension. Conflicts with pre-existing destination images are still handled by `conflictResolutionMode`.
+A `collection` item (entities collection ID) is resolved via `api.entities_collection.get_items()` into a flat list of images processed by a dedicated path (`copy_collection_items_to_dataset()` / `move_collection_items_to_dataset()`) — all images land in the destination dataset without preserving source structure. Works for both `default` and `aiSearch` collection types. Same-named images from different datasets are disambiguated upfront by `disambiguate_collection_names()`: every image involved in a name conflict gets `_<src dataset ID>` appended before the extension. Conflicts with pre-existing destination images are still handled by `conflictResolutionMode`. Auto-created filter collections (named like `Filtered entities <timestamp>`) are renamed by `rename_filtered_collection()` to `Data Commander (Task <ID>)` when processed.
 
 ## Docker
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -103,7 +103,9 @@ modal.state.items = [{"id":123,"type":"image"}]  # optional: scope to specific i
 TASK_ID = 57919
 ```
 
-`items` type values: `image`, `video`, `volume`, `pointcloud`, `pointcloud_episode`, `mesh`, `dataset`, `job`, `queue`
+`items` type values: `image`, `video`, `volume`, `pointcloud`, `pointcloud_episode`, `mesh`, `dataset`, `job`, `queue`, `collection`
+
+A `collection` item (entities collection ID) is resolved via `api.entities_collection.get_items()` into a flat list of images processed by a dedicated path (`copy_collection_items_to_dataset()` / `move_collection_items_to_dataset()`) — all images land in the destination dataset without preserving source structure. Works for both `default` and `aiSearch` collection types. Same-named images from different datasets are disambiguated upfront by `disambiguate_collection_names()`: every image involved in a name conflict gets `_<src dataset ID>` appended before the extension. Conflicts with pre-existing destination images are still handled by `conflictResolutionMode`.
 
 ## Docker
 

--- a/config.json
+++ b/config.json
@@ -6,7 +6,7 @@
   "headless": true,
   "main_script": "src/main.py",
   "docker_image": "supervisely/base-py-sdk-hardened:6.74.10",
-  "instance_version": "6.17.8",
+  "instance_version": "6.17.9",
   "system": true,
   "icon": "https://github.com/user-attachments/assets/673c34ac-2f58-4d1c-8679-439e85a25a45",
   "poster": "https://github.com/user-attachments/assets/09252852-3f49-4bad-b665-14e52458e4c0"

--- a/config.json
+++ b/config.json
@@ -6,7 +6,7 @@
   "headless": true,
   "main_script": "src/main.py",
   "docker_image": "supervisely/base-py-sdk-hardened:6.74.10",
-  "instance_version": "6.17.9",
+  "instance_version": "6.17.8",
   "system": true,
   "icon": "https://github.com/user-attachments/assets/673c34ac-2f58-4d1c-8679-439e85a25a45",
   "poster": "https://github.com/user-attachments/assets/09252852-3f49-4bad-b665-14e52458e4c0"

--- a/config.json
+++ b/config.json
@@ -5,8 +5,8 @@
   "type": "app",
   "headless": true,
   "main_script": "src/main.py",
-  "docker_image": "supervisely/base-py-sdk-hardened:6.74.0",
-  "instance_version": "6.17.0",
+  "docker_image": "supervisely/base-py-sdk-hardened:6.74.10",
+  "instance_version": "6.17.8",
   "system": true,
   "icon": "https://github.com/user-attachments/assets/673c34ac-2f58-4d1c-8679-439e85a25a45",
   "poster": "https://github.com/user-attachments/assets/09252852-3f49-4bad-b665-14e52458e4c0"

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,4 +1,4 @@
-FROM supervisely/base-py-sdk:6.74.0
+FROM supervisely/base-py-sdk-hardened:6.74.10
 
 # TEMPORARY: new feature support requires the unreleased SDK.
 # Pinned to a commit on branch refactor/<branch_name> — pip caches

--- a/src/main.py
+++ b/src/main.py
@@ -1,5 +1,6 @@
 import ast
 import os
+import re
 import tempfile
 from collections import defaultdict
 from concurrent.futures import ThreadPoolExecutor, as_completed, wait
@@ -2362,6 +2363,38 @@ def move_collection_items_to_dataset(
     return created_item_infos
 
 
+# auto-created filter collections are named like "Filtered entities 2026-07-03T14-31-57-501Z"
+FILTERED_COLLECTION_PATTERN = re.compile(
+    r"^Filtered entities \d{4}-\d{2}-\d{2}T\d{2}-\d{2}-\d{2}-\d{3}Z"
+)
+
+
+def rename_filtered_collection(collection_info) -> None:
+    """Rename an auto-created filter collection to reflect the task that processed it."""
+    if not FILTERED_COLLECTION_PATTERN.match(collection_info.name):
+        return
+    task_id = sly.env.task_id(raise_not_found=False)
+    if task_id is None:
+        return
+    new_name = f"Data Commander (Task {task_id})"
+    try:
+        api.entities_collection.update(collection_info.id, name=new_name)
+        logger.info(
+            "Collection renamed",
+            extra={
+                "collection_id": collection_info.id,
+                "old_name": collection_info.name,
+                "new_name": new_name,
+            },
+        )
+    except Exception as e:
+        logger.warning(
+            "Failed to rename collection: %s",
+            repr(e),
+            extra={"collection_id": collection_info.id},
+        )
+
+
 def resolve_collection_items(
     collection_items: List[Dict],
 ) -> Tuple[List[Dict], Optional[int]]:
@@ -2378,6 +2411,7 @@ def resolve_collection_items(
         collection_info = api.entities_collection.get_info_by_id(collection_id)
         if collection_info is None:
             raise ValueError(f"Collection with id={collection_id} not found")
+        rename_filtered_collection(collection_info)
         collection_project_id = collection_info.project_id
         collection_type = (
             CollectionTypeFilter.AI_SEARCH

--- a/src/main.py
+++ b/src/main.py
@@ -15,6 +15,7 @@ from dotenv import load_dotenv
 from supervisely import logger
 from supervisely._utils import generate_free_name
 from supervisely.annotation.tag_meta import TagApplicableTo, TagTargetType
+from supervisely.api.entities_collection_api import CollectionType, CollectionTypeFilter
 from supervisely.api.labeling_job_api import LabelingJobInfo
 from supervisely.geometry.closed_surface_mesh import ClosedSurfaceMesh
 from supervisely.project.project_settings import LabelingInterface
@@ -79,6 +80,7 @@ class JSONKEYS:
     NONE = "none"
     JOB = "job"
     QUEUE = "queue"
+    COLLECTION = "collection"
     PRESERVE_SRC_STRUCTURE = "preserveStructure"
     TRANSFER_MODE = "transferMode"
     SAVE_IDS_TO_PROJECT_CUSTOM_DATA = "saveIdsToProjectCustomData"
@@ -2265,6 +2267,138 @@ def move_items_to_dataset(
     return created_item_infos
 
 
+def disambiguate_collection_names(
+    item_infos: List[sly.ImageInfo],
+) -> List[sly.ImageInfo]:
+    """Rename images whose names repeat within the flat collection list.
+
+    A collection can contain same-named images from different datasets. Every
+    image involved in a name conflict gets its source dataset ID appended to
+    the name, so the origin of each copy stays visible in the destination.
+    """
+    name_counts = defaultdict(int)
+    for info in item_infos:
+        name_counts[info.name] += 1
+    used_names = {info.name for info in item_infos}
+    result = []
+    for info in item_infos:
+        if name_counts[info.name] < 2:
+            result.append(info)
+            continue
+        if "." in info.name:
+            stem, ext = info.name.rsplit(".", 1)
+            new_name = f"{stem}_{info.dataset_id}.{ext}"
+        else:
+            new_name = f"{info.name}_{info.dataset_id}"
+        new_name = generate_free_name(
+            used_names, new_name, with_ext=True, extend_used_names=True
+        )
+        logger.info(
+            "Duplicate image name in collection, renaming",
+            extra={
+                "image_id": info.id,
+                "old_name": info.name,
+                "new_name": new_name,
+                "src_dataset_id": info.dataset_id,
+            },
+        )
+        result.append(info._replace(name=new_name))
+    return result
+
+
+def copy_collection_items_to_dataset(
+    items: List[Dict],
+    project_type: str,
+    dst_dataset_id: int,
+    project_meta: sly.ProjectMeta,
+    options: Dict,
+    progress_cb=None,
+):
+    item_ids = [item[JSONKEYS.ID] for item in items]
+    item_infos = get_item_infos(None, item_ids, project_type)
+    item_infos = disambiguate_collection_names(item_infos)
+    created_item_infos = clone_items(
+        None,
+        dst_dataset_id,
+        project_type=project_type,
+        project_meta=project_meta,
+        options=options,
+        progress_cb=progress_cb,
+        src_infos=item_infos,
+    )
+    return created_item_infos
+
+
+def move_collection_items_to_dataset(
+    items: List[Dict],
+    project_type: str,
+    dst_dataset_id: int,
+    project_meta: sly.ProjectMeta,
+    options: Dict,
+    progress_cb=None,
+):
+    global cancel_deletion
+
+    item_ids = [item[JSONKEYS.ID] for item in items]
+    item_infos = get_item_infos(None, item_ids, project_type)
+    item_infos = disambiguate_collection_names(item_infos)
+    created_item_infos = clone_items(
+        None,
+        dst_dataset_id,
+        project_type=project_type,
+        project_meta=project_meta,
+        options=options,
+        progress_cb=progress_cb,
+        src_infos=item_infos,
+    )
+    if cancel_deletion or len(created_item_infos) < len(item_infos):
+        logger.info(
+            "Some items were not moved. Skipping deletion of source items",
+            extra={"dataset_id": dst_dataset_id},
+        )
+    else:
+        delete_items(item_infos)
+    cancel_deletion = False
+    return created_item_infos
+
+
+def resolve_collection_items(
+    collection_items: List[Dict],
+) -> Tuple[List[Dict], Optional[int]]:
+    """Expand collection items into a flat list of image items.
+
+    Returns the image items and the project ID of the last resolved collection
+    (used as a fallback when the source project is not set in the state).
+    """
+    image_items = []
+    seen_image_ids = set()
+    collection_project_id = None
+    for item in collection_items:
+        collection_id = item[JSONKEYS.ID]
+        collection_info = api.entities_collection.get_info_by_id(collection_id)
+        if collection_info is None:
+            raise ValueError(f"Collection with id={collection_id} not found")
+        collection_project_id = collection_info.project_id
+        collection_type = (
+            CollectionTypeFilter.AI_SEARCH
+            if collection_info.type == CollectionType.AI_SEARCH
+            else CollectionTypeFilter.DEFAULT
+        )
+        collection_image_infos = api.entities_collection.get_items(
+            collection_id, collection_type, collection_info.project_id
+        )
+        logger.info(
+            "Resolved collection into %d images",
+            len(collection_image_infos),
+            extra={"collection_id": collection_id},
+        )
+        for info in collection_image_infos:
+            if info.id not in seen_image_ids:
+                seen_image_ids.add(info.id)
+                image_items.append({JSONKEYS.ID: info.id, JSONKEYS.TYPE: JSONKEYS.IMAGE})
+    return image_items, collection_project_id
+
+
 def copy_or_move(state: Dict, move: bool = False):
     source = state[JSONKEYS.SOURCE]
     destination = state[JSONKEYS.DESTINATION]
@@ -2294,6 +2428,23 @@ def copy_or_move(state: Dict, move: bool = False):
     project_items = [item for item in items if item[JSONKEYS.TYPE] == JSONKEYS.PROJECT]
     dataset_items = [item for item in items if item[JSONKEYS.TYPE] == JSONKEYS.DATASET]
     image_items = [item for item in items if item[JSONKEYS.TYPE] == JSONKEYS.IMAGE]
+    collection_items = [
+        item for item in items if item[JSONKEYS.TYPE] == JSONKEYS.COLLECTION
+    ]
+
+    collection_image_items = []
+    if len(collection_items) > 0:
+        collection_image_items, collection_project_id = resolve_collection_items(
+            collection_items
+        )
+        if src_project_id is None:
+            src_project_id = collection_project_id
+        explicit_image_ids = {item[JSONKEYS.ID] for item in image_items}
+        collection_image_items = [
+            item
+            for item in collection_image_items
+            if item[JSONKEYS.ID] not in explicit_image_ids
+        ]
 
     items_to_create = 0
     src_project_infos: Dict[int, sly.ProjectInfo] = {}
@@ -2323,11 +2474,11 @@ def copy_or_move(state: Dict, move: bool = False):
         items_to_create += _count_items_in_tree(datasets_tree)
         project_meta = merge_project_meta(src_project_id, dst_project_id)
 
-    if len(image_items) > 0:
+    if len(image_items) > 0 or len(collection_image_items) > 0:
         src_project_infos.setdefault(
             src_project_id, api.project.get_info_by_id(src_project_id, raise_error=True)
         )
-        items_to_create += len(image_items)
+        items_to_create += len(image_items) + len(collection_image_items)
         if project_meta is None:
             project_meta = merge_project_meta(src_project_id, dst_project_id)
 
@@ -2377,6 +2528,27 @@ def copy_or_move(state: Dict, move: bool = False):
                 dst_dataset_id=dst_dataset_id,
                 options=options,
                 progress_cb=_progress_cb,
+            )
+    if len(collection_image_items) > 0:
+        assign_workflow(src_project_id, dst_project_id)
+        project_type = src_project_infos[src_project_id].type
+        if move:
+            move_collection_items_to_dataset(
+                collection_image_items,
+                project_type,
+                dst_dataset_id,
+                project_meta,
+                options,
+                _progress_cb,
+            )
+        else:
+            copy_collection_items_to_dataset(
+                collection_image_items,
+                project_type,
+                dst_dataset_id,
+                project_meta,
+                options,
+                _progress_cb,
             )
     if len(image_items) > 0:
         assign_workflow(src_project_id, dst_project_id)

--- a/src/main.py
+++ b/src/main.py
@@ -2277,6 +2277,9 @@ def disambiguate_collection_names(
     image involved in a name conflict gets its source dataset ID appended to
     the name, so the origin of each copy stays visible in the destination.
     """
+    progress = sly.Progress(
+        message="Checking for duplicate names", total_cnt=len(item_infos)
+    )
     name_counts = defaultdict(int)
     for info in item_infos:
         name_counts[info.name] += 1
@@ -2285,6 +2288,7 @@ def disambiguate_collection_names(
     for info in item_infos:
         if name_counts[info.name] < 2:
             result.append(info)
+            progress.iter_done_report()
             continue
         if "." in info.name:
             stem, ext = info.name.rsplit(".", 1)
@@ -2304,6 +2308,7 @@ def disambiguate_collection_names(
             },
         )
         result.append(info._replace(name=new_name))
+        progress.iter_done_report()
     return result
 
 

--- a/src/main.py
+++ b/src/main.py
@@ -2513,7 +2513,7 @@ def copy_or_move(state: Dict, move: bool = False):
             src_project_id, api.project.get_info_by_id(src_project_id, raise_error=True)
         )
         items_to_create += len(image_items) + len(collection_image_items)
-        if project_meta is None:
+        if project_meta is None and dst_project_id is not None:
             project_meta = merge_project_meta(src_project_id, dst_project_id)
 
     progress.total = items_to_create
@@ -2564,14 +2564,53 @@ def copy_or_move(state: Dict, move: bool = False):
                 progress_cb=_progress_cb,
             )
     if len(collection_image_items) > 0:
-        assign_workflow(src_project_id, dst_project_id)
-        project_type = src_project_infos[src_project_id].type
+        src_project_info = src_project_infos[src_project_id]
+        project_type = src_project_info.type
+        # collections are transferred as a flat list into a single dataset;
+        # create the missing destination levels when needed
+        collection_dst_project_id = dst_project_id
+        collection_dst_dataset_id = dst_dataset_id
+        if collection_dst_dataset_id is None:
+            if collection_dst_project_id is None:
+                created_project = api.project.create(
+                    dst_workspace_id,
+                    src_project_info.name,
+                    type=project_type,
+                    change_name_if_conflict=True,
+                )
+                collection_dst_project_id = created_project.id
+                logger.info(
+                    "Created project for collection items",
+                    extra={
+                        "project_id": created_project.id,
+                        "project_name": created_project.name,
+                    },
+                )
+            created_dataset = api.dataset.create(
+                collection_dst_project_id,
+                f"Collection {collection_items[0][JSONKEYS.ID]}",
+                change_name_if_conflict=True,
+            )
+            collection_dst_dataset_id = created_dataset.id
+            logger.info(
+                "Created dataset for collection items",
+                extra={
+                    "dataset_id": created_dataset.id,
+                    "dataset_name": created_dataset.name,
+                },
+            )
+        collection_project_meta = project_meta
+        if collection_project_meta is None or collection_dst_project_id != dst_project_id:
+            collection_project_meta = merge_project_meta(
+                src_project_id, collection_dst_project_id
+            )
+        assign_workflow(src_project_id, collection_dst_project_id)
         if move:
             move_collection_items_to_dataset(
                 collection_image_items,
                 project_type,
-                dst_dataset_id,
-                project_meta,
+                collection_dst_dataset_id,
+                collection_project_meta,
                 options,
                 _progress_cb,
             )
@@ -2579,8 +2618,8 @@ def copy_or_move(state: Dict, move: bool = False):
             copy_collection_items_to_dataset(
                 collection_image_items,
                 project_type,
-                dst_dataset_id,
-                project_meta,
+                collection_dst_dataset_id,
+                collection_project_meta,
                 options,
                 _progress_cb,
             )

--- a/src/main.py
+++ b/src/main.py
@@ -2314,10 +2314,12 @@ def copy_collection_items_to_dataset(
     project_meta: sly.ProjectMeta,
     options: Dict,
     progress_cb=None,
+    src_infos: Optional[List[sly.ImageInfo]] = None,
 ):
-    item_ids = [item[JSONKEYS.ID] for item in items]
-    item_infos = get_item_infos(None, item_ids, project_type)
-    item_infos = disambiguate_collection_names(item_infos)
+    if src_infos is None:
+        item_ids = [item[JSONKEYS.ID] for item in items]
+        src_infos = get_item_infos(None, item_ids, project_type)
+    item_infos = disambiguate_collection_names(src_infos)
     created_item_infos = clone_items(
         None,
         dst_dataset_id,
@@ -2337,12 +2339,14 @@ def move_collection_items_to_dataset(
     project_meta: sly.ProjectMeta,
     options: Dict,
     progress_cb=None,
+    src_infos: Optional[List[sly.ImageInfo]] = None,
 ):
     global cancel_deletion
 
-    item_ids = [item[JSONKEYS.ID] for item in items]
-    item_infos = get_item_infos(None, item_ids, project_type)
-    item_infos = disambiguate_collection_names(item_infos)
+    if src_infos is None:
+        item_ids = [item[JSONKEYS.ID] for item in items]
+        src_infos = get_item_infos(None, item_ids, project_type)
+    item_infos = disambiguate_collection_names(src_infos)
     created_item_infos = clone_items(
         None,
         dst_dataset_id,
@@ -2397,14 +2401,16 @@ def rename_filtered_collection(collection_info) -> None:
 
 def resolve_collection_items(
     collection_items: List[Dict],
-) -> Tuple[List[Dict], Optional[int]]:
+) -> Tuple[List[Dict], Optional[int], Dict[int, sly.ImageInfo]]:
     """Expand collection items into a flat list of image items.
 
-    Returns the image items and the project ID of the last resolved collection
-    (used as a fallback when the source project is not set in the state).
+    Returns the image items, the project ID of the last resolved collection
+    (used as a fallback when the source project is not set in the state), and
+    the already-fetched ImageInfo per image ID — reused later to clone items
+    without fetching the same data from the API a second time.
     """
     image_items = []
-    seen_image_ids = set()
+    image_infos_by_id = {}
     collection_project_id = None
     for item in collection_items:
         collection_id = item[JSONKEYS.ID]
@@ -2418,27 +2424,19 @@ def resolve_collection_items(
             if collection_info.type == CollectionType.AI_SEARCH
             else CollectionTypeFilter.DEFAULT
         )
-        # only image IDs are needed here; the full ImageInfo is fetched again
-        # right before cloning, so avoid materializing it twice for large collections
-        list_kwargs = dict(
-            project_id=collection_info.project_id,
-            fields=[sly.api.ApiField.ID, sly.api.ApiField.NAME],
+        collection_image_infos = api.entities_collection.get_items(
+            collection_id, collection_type, collection_info.project_id
         )
-        if collection_type == CollectionTypeFilter.AI_SEARCH:
-            list_kwargs["ai_search_collection_id"] = collection_id
-        else:
-            list_kwargs["entities_collection_id"] = collection_id
-        collection_image_ids = [info.id for info in api.image.get_list(**list_kwargs)]
         logger.info(
             "Resolved collection into %d images",
-            len(collection_image_ids),
+            len(collection_image_infos),
             extra={"collection_id": collection_id},
         )
-        for image_id in collection_image_ids:
-            if image_id not in seen_image_ids:
-                seen_image_ids.add(image_id)
-                image_items.append({JSONKEYS.ID: image_id, JSONKEYS.TYPE: JSONKEYS.IMAGE})
-    return image_items, collection_project_id
+        for info in collection_image_infos:
+            if info.id not in image_infos_by_id:
+                image_infos_by_id[info.id] = info
+                image_items.append({JSONKEYS.ID: info.id, JSONKEYS.TYPE: JSONKEYS.IMAGE})
+    return image_items, collection_project_id, image_infos_by_id
 
 
 def copy_or_move(state: Dict, move: bool = False):
@@ -2475,9 +2473,10 @@ def copy_or_move(state: Dict, move: bool = False):
     ]
 
     collection_image_items = []
+    collection_src_infos = []
     if len(collection_items) > 0:
-        collection_image_items, collection_project_id = resolve_collection_items(
-            collection_items
+        collection_image_items, collection_project_id, collection_image_infos_by_id = (
+            resolve_collection_items(collection_items)
         )
         if src_project_id is None:
             src_project_id = collection_project_id
@@ -2486,6 +2485,12 @@ def copy_or_move(state: Dict, move: bool = False):
             item
             for item in collection_image_items
             if item[JSONKEYS.ID] not in explicit_image_ids
+        ]
+        # reuse the ImageInfo already fetched while resolving the collection
+        # instead of fetching the same images again right before cloning
+        collection_src_infos = [
+            collection_image_infos_by_id[item[JSONKEYS.ID]]
+            for item in collection_image_items
         ]
 
     items_to_create = 0
@@ -2582,6 +2587,7 @@ def copy_or_move(state: Dict, move: bool = False):
                 project_meta,
                 options,
                 _progress_cb,
+                src_infos=collection_src_infos,
             )
         else:
             copy_collection_items_to_dataset(
@@ -2591,6 +2597,7 @@ def copy_or_move(state: Dict, move: bool = False):
                 project_meta,
                 options,
                 _progress_cb,
+                src_infos=collection_src_infos,
             )
     if len(image_items) > 0:
         assign_workflow(src_project_id, dst_project_id)

--- a/src/main.py
+++ b/src/main.py
@@ -2418,18 +2418,26 @@ def resolve_collection_items(
             if collection_info.type == CollectionType.AI_SEARCH
             else CollectionTypeFilter.DEFAULT
         )
-        collection_image_infos = api.entities_collection.get_items(
-            collection_id, collection_type, collection_info.project_id
+        # only image IDs are needed here; the full ImageInfo is fetched again
+        # right before cloning, so avoid materializing it twice for large collections
+        list_kwargs = dict(
+            project_id=collection_info.project_id,
+            fields=[sly.api.ApiField.ID, sly.api.ApiField.NAME],
         )
+        if collection_type == CollectionTypeFilter.AI_SEARCH:
+            list_kwargs["ai_search_collection_id"] = collection_id
+        else:
+            list_kwargs["entities_collection_id"] = collection_id
+        collection_image_ids = [info.id for info in api.image.get_list(**list_kwargs)]
         logger.info(
             "Resolved collection into %d images",
-            len(collection_image_infos),
+            len(collection_image_ids),
             extra={"collection_id": collection_id},
         )
-        for info in collection_image_infos:
-            if info.id not in seen_image_ids:
-                seen_image_ids.add(info.id)
-                image_items.append({JSONKEYS.ID: info.id, JSONKEYS.TYPE: JSONKEYS.IMAGE})
+        for image_id in collection_image_ids:
+            if image_id not in seen_image_ids:
+                seen_image_ids.add(image_id)
+                image_items.append({JSONKEYS.ID: image_id, JSONKEYS.TYPE: JSONKEYS.IMAGE})
     return image_items, collection_project_id
 
 

--- a/src/main.py
+++ b/src/main.py
@@ -2513,7 +2513,7 @@ def copy_or_move(state: Dict, move: bool = False):
             src_project_id, api.project.get_info_by_id(src_project_id, raise_error=True)
         )
         items_to_create += len(image_items) + len(collection_image_items)
-        if project_meta is None and dst_project_id is not None:
+        if project_meta is None:
             project_meta = merge_project_meta(src_project_id, dst_project_id)
 
     progress.total = items_to_create
@@ -2564,53 +2564,14 @@ def copy_or_move(state: Dict, move: bool = False):
                 progress_cb=_progress_cb,
             )
     if len(collection_image_items) > 0:
-        src_project_info = src_project_infos[src_project_id]
-        project_type = src_project_info.type
-        # collections are transferred as a flat list into a single dataset;
-        # create the missing destination levels when needed
-        collection_dst_project_id = dst_project_id
-        collection_dst_dataset_id = dst_dataset_id
-        if collection_dst_dataset_id is None:
-            if collection_dst_project_id is None:
-                created_project = api.project.create(
-                    dst_workspace_id,
-                    src_project_info.name,
-                    type=project_type,
-                    change_name_if_conflict=True,
-                )
-                collection_dst_project_id = created_project.id
-                logger.info(
-                    "Created project for collection items",
-                    extra={
-                        "project_id": created_project.id,
-                        "project_name": created_project.name,
-                    },
-                )
-            created_dataset = api.dataset.create(
-                collection_dst_project_id,
-                f"Collection {collection_items[0][JSONKEYS.ID]}",
-                change_name_if_conflict=True,
-            )
-            collection_dst_dataset_id = created_dataset.id
-            logger.info(
-                "Created dataset for collection items",
-                extra={
-                    "dataset_id": created_dataset.id,
-                    "dataset_name": created_dataset.name,
-                },
-            )
-        collection_project_meta = project_meta
-        if collection_project_meta is None or collection_dst_project_id != dst_project_id:
-            collection_project_meta = merge_project_meta(
-                src_project_id, collection_dst_project_id
-            )
-        assign_workflow(src_project_id, collection_dst_project_id)
+        assign_workflow(src_project_id, dst_project_id)
+        project_type = src_project_infos[src_project_id].type
         if move:
             move_collection_items_to_dataset(
                 collection_image_items,
                 project_type,
-                collection_dst_dataset_id,
-                collection_project_meta,
+                dst_dataset_id,
+                project_meta,
                 options,
                 _progress_cb,
             )
@@ -2618,8 +2579,8 @@ def copy_or_move(state: Dict, move: bool = False):
             copy_collection_items_to_dataset(
                 collection_image_items,
                 project_type,
-                collection_dst_dataset_id,
-                collection_project_meta,
+                dst_dataset_id,
+                project_meta,
                 options,
                 _progress_cb,
             )


### PR DESCRIPTION
## Description

Adds `collection` as a supported `items` type for `copy` / `move` actions: an entities collection is resolved into a flat list of images and transferred into the destination dataset without preserving source structure.

## Changes

- `resolve_collection_items()` — resolves each collection item into a flat list of image items. Supports both `default` and `aiSearch` collection types. Falls back to the collection's own `project_id` when `source.project.id` is not set in the state.
- `copy_collection_items_to_dataset()` / `move_collection_items_to_dataset()` — dedicated processing path: all images land in the destination dataset without preserving source structure. Move keeps the existing safety net: source items are not deleted unless every item was transferred.
- `disambiguate_collection_names()` — a collection can contain same-named images from different datasets; every image involved in a name conflict gets `_<src dataset ID>` appended before the extension (e.g. `img.png` from datasets 100 and 200 → `img_100.png` / `img_200.png`), so the origin of each copy stays visible. Residual collisions are resolved via `generate_free_name`. Without this, `skip`/`replace` modes silently dropped duplicates (and cancelled source deletion on move), while `rename` mode could fail the whole upload batch.
- `rename_filtered_collection()` — auto-created filter collections (named like `Filtered entities 2026-07-03T14-31-57-501Z`) are renamed to `Data Commander (Task <ID>)` when the task processes them, so it is clear which task handled the collection. Collections with custom names are left untouched; a rename failure does not fail the task.
- Conflicts with pre-existing destination images are still handled by `options.conflictResolutionMode`; conflicts within the flat collection list itself are resolved unconditionally by `disambiguate_collection_names()` before that logic runs.
- Images listed both explicitly and via a collection are transferred once.
- The `ImageInfo` fetched while resolving the collection is reused for cloning instead of being fetched again by ID right before cloning — avoids a redundant full API round-trip for large collections.

## State example

```json
{
  "state": {
    "action": "copy",
    "options": {"conflictResolutionMode": "rename", "cloneAnnotations": true, "preserveSrcDate": false},
    "items": [{"id": 2863, "type": "collection"}],
    "source": {"team": {"id": 10}, "workspace": {"id": 9}, "project": {"id": 7548}},
    "destination": {"team": {"id": 10}, "workspace": {"id": 9}, "project": {"id": 7549}, "dataset": {"id": 45188}}
  }
}
```

The destination is expected to always include a project and a dataset for collection items, matching the contract above.

## Notes

- Name disambiguation logic covered by standalone checks: two datasets, triple duplicate, name without extension, suffix collision with an existing name.